### PR TITLE
Remove `wp-block` maximum width from the appender

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -54,6 +54,10 @@
 		width: 100%;
 		z-index: 1;
 		position: relative;
+
+		> .block-list-appender {
+			max-width: 100%;
+		}
 	}
 
 	&__video-background {


### PR DESCRIPTION
I have made the block appender full-width to fill the container content when the container has alignfull.

![image](https://user-images.githubusercontent.com/25322810/117861156-caf92c80-b299-11eb-98c5-9f380d6a8521.png)
