### PR TITLE
ISO Encoding 🐞 🥇  (v1.1.2)

### DIFF
--- a/block/class-container.php
+++ b/block/class-container.php
@@ -88,7 +88,7 @@ if ( ! class_exists( Container::class ) ) :
 				}
 
 				libxml_clear_errors();
-				$content = utf8_decode( $dom->saveHTML( $dom->documentElement ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$content = $dom->saveHTML( $dom->documentElement ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			}
 
 			/**

--- a/index.php
+++ b/index.php
@@ -5,7 +5,7 @@
  * @wordpress-plugin
  * Plugin Name:          sixa - Container Block
  * Description:          Wrap several blocks in a parent wrapper and do more styling.
- * Version:              1.1.1
+ * Version:              1.1.2
  * Requires at least:    5.7
  * Requires PHP:         7.4
  * Author:               sixa AG

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sixach/wp-block-container",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixach/wp-block-container",
-			"version": "1.1.1",
+			"version": "1.1.2",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@sixa/icon-library": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixach/wp-block-container",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"private": true,
 	"description": "Wrap several blocks in a parent wrapper and do more styling as well.",
 	"keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://sixa.com/
 Tags: container, group, section, wrapper, block, gutenberg, sixa
 Requires at least: 5.7
 Tested up to: 5.9
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 Requires PHP: 7.4
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -108,6 +108,9 @@ If you need professional support for this or any other WordPress project, please
 2. Container as hero section with a background image and a title
 
 == Changelog ==
+= 1.1.2 =
+* Fixed incorrect character encoding in block content
+
 = 1.1.1 =
 * Added compatibility with WordPress 5.9
 
@@ -118,6 +121,9 @@ If you need professional support for this or any other WordPress project, please
 * Initial release
 
 == Upgrade Notice ==
+= 1.1.1 =
+Upgrade to fix a bug with incorrectly encoded block content.
+
 = 1.1.1 =
 Upgrade for compatibility with WordPress 5.9.
 

--- a/readme.txt
+++ b/readme.txt
@@ -121,7 +121,7 @@ If you need professional support for this or any other WordPress project, please
 * Initial release
 
 == Upgrade Notice ==
-= 1.1.1 =
+= 1.1.2 =
 Upgrade to fix a bug with incorrectly encoded block content.
 
 = 1.1.1 =


### PR DESCRIPTION
This PR removes the call to `utf8_decode` to prevent the block content to be encoded in ISO-8859-1. This prevents incompatibility with UTF-8 characters, which are very commonly used in languages like German and French.

This PR also bumps the version of the plugin and updates the `readme.txt` accordingly.